### PR TITLE
Fix type annotations in render_tiles in warp.py

### DIFF
--- a/warp.py
+++ b/warp.py
@@ -310,8 +310,8 @@ def render_tiles(
     margin_overrides: Optional[Dict[Tuple[int, int], Tuple[int, int, int,
                                                            int]]] = None,
     return_warped_tiles: bool = False
-) -> Union[tuple[np.ndarray, np.ndarray], tuple[np.ndarray, np.ndarray, dict[
-    tuple[int, int], Any]]]:
+) -> Union[Tuple[np.ndarray, np.ndarray], Tuple[np.ndarray, np.ndarray, Dict[
+    Tuple[int, int], Any]]]:
   """Warps a collection of tiles into a larger image.
 
   All values in the 'tiles' and 'positions' maps are assumed to


### PR DESCRIPTION
In higher versions of python (>=3.8), you cannot import the `warp.py' module

![sofima-typing](https://user-images.githubusercontent.com/12106104/212165494-1e564ef9-bc3b-42bf-92ee-bd2a785dc594.png)

This error is caused by tuple[int,int] which is not allowed in the function definition, 
as this is subscripting the type `tuple'

So we replace tuple -> Tuple and dict -> Dict 